### PR TITLE
Support when `false` is returned for the title

### DIFF
--- a/shared/Contents/Scripts/shared.js
+++ b/shared/Contents/Scripts/shared.js
@@ -102,10 +102,13 @@ function getUrl(url, params) {
 function postsAsListResults(posts) {
 	return posts.map(function(post) {
 		var result = {
-			title: post.description,
 			url: post.href,
 			icon: 'BookmarkTemplate.icns'
 		};
+		
+		result.title = post.description
+			? post.description
+			: post.href;
 
 		result.subtitle = post.extended
 			? post.extended


### PR DESCRIPTION
There is a case where the api returns `false` for the title when there is a broken character in the title string (there could be other cases, but that's the one I've noticed.)
This causes actions to fail, which this works around.